### PR TITLE
Replace Black Friday campaign with Anticipation campaign

### DIFF
--- a/PopUp/popup.json
+++ b/PopUp/popup.json
@@ -1,20 +1,19 @@
 [
-    {
-        "nome": "Campanha Black Friday 2025",
-        "imagem": "https://raw.githubusercontent.com/f360-dev/marketplace-f360/main/PopUp/imagens/F360-black-friday-2025.png",
-        "link": "https://conteudo.f360.com.br/black-financas-2025",
-        "localStorageId": "blackfriday14102025",
-        "categoria": "Pop-up - Campanha Black Friday 2025",
-        "inicio": "2025/10/13",
-        "fim": "2025/10/17",
-        "action": "Saiba Mais",
-        "preventClient": [
-          "CDS"
-        ],
-        "preventCli": [],
-        "direcionarCampanha": [],
-        "closeColor": "#fff"
-      }
-  ]
-  
-
+  {
+      "nome": "Campanha Antecipação 2025",
+      "imagem": "https://raw.githubusercontent.com/f360-dev/marketplace-f360/main/PopUp/imagens/F360-campanha-antecipa-2025.jpg",
+      "link": "#",
+      "localStorageId": "antecipa202512091228",
+      "categoria": "Pop-up - Campanha Antecipação 2025",
+      "inicio": "2025/12/08",
+      "fim": "2025/12/31",
+      "action": "",
+      "preventClient": [
+        "CDS",
+        "Antecipa"
+      ],
+      "preventCli": [],
+      "direcionarCampanha": [],
+      "closeColor": "#fff"
+    }
+]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Atualizações**
  * Nova campanha de Antecipação 2025 disponível, substituindo a campanha anterior, com período de vigência em dezembro.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->